### PR TITLE
Handle fatal when api is not set

### DIFF
--- a/inc/dashboard-assistant/namespace.php
+++ b/inc/dashboard-assistant/namespace.php
@@ -19,10 +19,14 @@ function bootstrap() : void {
 
 	$assistant_id = get_option( 'ai_my_assistant_id' );
 
-	if ( ! $assistant_id ) {
-		$assistant = create_assisant();
-	} else {
-		$assistant = OpenAI\Client::get_instance()->get_assistant( get_option( 'ai_my_assistant_id' ) );
+	try {
+		if ( ! $assistant_id ) {
+			$assistant = create_assisant();
+		} else {
+			$assistant = OpenAI\Client::get_instance()->get_assistant( get_option( 'ai_my_assistant_id' ) );
+		}
+	} catch ( Exception $e ) {
+		return;
 	}
 
 	$assistant->register_function( OpenAI\Function_::from_callable( get_posts( ... ) ) );


### PR DESCRIPTION
This allows the user to set up the API key from the option page: `wp-admin/options-general.php?page=ai-plugin-settings`